### PR TITLE
Add Ollama configuration documentation to MCP server README

### DIFF
--- a/mcp_server/.env.example
+++ b/mcp_server/.env.example
@@ -22,6 +22,15 @@ EMBEDDER_MODEL_NAME=text-embedding-3-small
 # MODEL_NAME=gemini-2.0-flash
 # EMBEDDER_MODEL_NAME=gemini-embedding-001
 
+# Ollama Configuration (alternative for local models)
+# To use local Ollama models, uncomment and configure these settings
+# OPENAI_API_KEY=ollama
+# MODEL_NAME=qwen2.5-coder:7b
+# SMALL_MODEL_NAME=qwen2.5-coder:7b
+# EMBEDDER_MODEL_NAME=nomic-embed-text:latest
+# OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+# SEMAPHORE_LIMIT=1
+
 # Optional: Group ID for namespacing graph data
 # GROUP_ID=my_project
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -166,6 +166,42 @@ Before running the Docker Compose setup, you need to configure the environment v
      OPENAI_API_KEY=your_key MODEL_NAME=gpt-4.1-mini docker compose up
      ```
 
+#### Ollama Configuration
+
+The Graphiti MCP server can be configured to use local Ollama models instead of cloud-based LLM providers. This is useful for running completely local AI operations.
+
+To configure Ollama:
+
+1. **Install and start Ollama** on your host machine following the [Ollama installation guide](https://ollama.ai/)
+
+2. **Pull the required models**:
+   ```bash
+   ollama pull qwen2.5-coder:7b
+   ollama pull nomic-embed-text:latest
+   ```
+
+3. **Update your .env file** with Ollama configuration:
+   ```
+   # Ollama Configuration
+   OPENAI_API_KEY=ollama
+   MODEL_NAME=qwen2.5-coder:7b
+   SMALL_MODEL_NAME=qwen2.5-coder:7b
+   EMBEDDER_MODEL_NAME=nomic-embed-text:latest
+   
+   # For Docker: use host.docker.internal to access host machine's Ollama
+   OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+   
+   # Optional: Reduce concurrency for local models
+   SEMAPHORE_LIMIT=1
+   ```
+
+4. **Start the service** using Docker Compose as usual:
+   ```bash
+   docker compose up
+   ```
+
+The Docker container will connect to your host machine's Ollama instance using `host.docker.internal:11434`.
+
 #### Neo4j Configuration
 
 The Docker Compose setup includes a Neo4j container with the following default configuration:


### PR DESCRIPTION
## Summary
- Added comprehensive Ollama configuration section to the MCP server README
- Includes step-by-step setup instructions for local Ollama models
- Documents configuration for qwen2.5-coder:7b and nomic-embed-text models
- Explains Docker connectivity using host.docker.internal

## Test plan
- [ ] Verify README formatting renders correctly
- [ ] Test Ollama setup instructions with fresh installation
- [ ] Confirm Docker connectivity to host Ollama instance

🤖 Generated with [Claude Code](https://claude.ai/code)